### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ActorDB for Docker
-[![Docker Automated build](https://img.shields.io/docker/automated/bytepixie/actordb.svg?maxAge=2592000)](https://github.com/bytepixie/actordb-for-docker/tree/master/build/) [![license](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)](https://github.com/bytepixie/actordb-for-docker/blob/master/LICENSE)
+[![Docker Automated build](https://img.shields.io/docker/automated/bytepixie/actordb.svg?maxAge=2592000)](https://github.com/bytepixie/actordb-for-docker/tree/master/build/) [![](https://images.microbadger.com/badges/image/bytepixie/actordb.svg)](https://microbadger.com/images/bytepixie/actordb "Get your own image badge on microbadger.com") [![license](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)](https://github.com/bytepixie/actordb-for-docker/blob/master/LICENSE)
 
 A project to get [ActorDB](http://www.actordb.com) running with [Docker](https://www.docker.com).
 
@@ -12,3 +12,4 @@ The root of this project has a very rudimentary [docker-compose.yml](https://git
 ## Contributing & Issues
 If you have problems with or questions about this image, please raise an issue on the [GitHub repo](https://github.com/bytepixie/actordb-for-docker/issues).
 Pull requests are even better!
+ 

--- a/build/README.md
+++ b/build/README.md
@@ -1,5 +1,5 @@
 # ActorDB for Docker
-[![Docker Automated build](https://img.shields.io/docker/automated/bytepixie/actordb.svg?maxAge=2592000)](https://github.com/bytepixie/actordb-for-docker/tree/master/build/)
+[![Docker Automated build](https://img.shields.io/docker/automated/bytepixie/actordb.svg?maxAge=2592000)](https://github.com/bytepixie/actordb-for-docker/tree/master/build/) [![](https://images.microbadger.com/badges/image/bytepixie/actordb.svg)](https://microbadger.com/images/bytepixie/actordb "Get your own image badge on microbadger.com")
 
 **PLEASE NOTE:** *This is an unofficial package, [go badger Biokoda](https://github.com/biokoda/actordb/issues) for an official [ActorDB](http://www.actordb.com) image if that is of concern!*
 


### PR DESCRIPTION
We saw your image on Docker Hub at [bytepixie/actordb](https://hub.docker.com/r/bytepixie/actordb/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/bytepixie/actordb).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/bytepixie/actordb.svg)](https://microbadger.com/images/bytepixie/actordb)
