### PR TITLE
User permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /node*/logs/error.log*
 /node*/logs/sasl-error.log*
 .env
+/actordb-data
+/actordb-etc
+/actordb-logs

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /node*/logs/crash.log*
 /node*/logs/error.log*
 /node*/logs/sasl-error.log*
+.env

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -27,6 +27,10 @@ RUN apt-get update \
 	&& rm -rf /var/lib/apt/lists/* /tmp/*
 
 #
+# Bootstrap script.
+COPY ./docker-entrypoint.sh /
+
+#
 # Default Thrift and MySQL client ports.
 EXPOSE 33306 33307
 #
@@ -41,4 +45,4 @@ VOLUME /var/lib/actordb /etc/actordb /var/log/actordb
 #
 # Use dumb-init to make sure actordb is not running as PID 1.
 ENTRYPOINT ["dumb-init"]
-CMD ["actordb", "foreground"]
+CMD ["/docker-entrypoint.sh"]

--- a/build/README.md
+++ b/build/README.md
@@ -138,6 +138,19 @@ By default the image exposes three volumes:
 * /etc/actordb: Configuration files.
 * /var/log/actordb: Log files.
 
+You probably want to mount at least the data and logs volumes in order to persist your data and inspect the logs. If the config volume isn't mounted then a default config is used, but if mounted you'll need to supply an `app.config` and `vm.args` file.
+
+### Environment Variables
+
+#### `NEW_UID`
+Set the user ID that the `actordb` user should use, great for ensuring that data is created with the same UID as the host user running the container and therefore more manageable on the host.
+
+#### `NEW_GID`
+Set the group ID that the `actordb` user should use, great for ensuring that data is created with the same GID as the host user running the container and therefore more manageable on the host.
+
+#### `ACTORDB_NODE`
+Overrides the `-name` setting from the vm.args file to give the node a new name when the container is first started. If not used then the node name from the /etc/actordb/vm.args file is used (default is actordb@actordb.local).
+
 ### User
 The default user is root, but the actordb process runs as an "actordb" user.
 
@@ -146,8 +159,8 @@ Some things to remember when configuring ActorDB.
 
 Each node you bring up *must* have a unique `-name` in its vm.args file. This means the part *before* the "@".
 
-When using Docker, you can use the `--name` you give the container after the "@" in the `-name` setting of vm.args.
-When using Docker Compose, you can use the service name after the "@" in the `-name` setting of vm.args.
+When using Docker, you can use the `--name` you give the container after the "@" in the `-name` setting of vm.args (also see the `ACTORDB_NODE` environment variable).
+When using Docker Compose, you can use the service name after the "@" in the `-name` setting of vm.args to ensure the nodes can chat.
 
 You *must* remember to add each node that makes up a cluster into the nodes table. In the example `init.example.sql` it only inserts the current node's name, but you'll want to add the others.
 

--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -9,7 +9,6 @@ ACTORDB_UID=`id -u ${ACTORDB_USER}`
 ACTORDB_GID=`id -g ${ACTORDB_GROUP}`
 DEBUG_COMMANDS=0
 
-
 #
 # Functions
 #
@@ -124,6 +123,22 @@ fi
 run "chown -R ${ACTORDB_USER}:${ACTORDB_GROUP} /var/lib/actordb"
 run "chown -R ${ACTORDB_USER}:${ACTORDB_GROUP} /etc/actordb"
 run "chown -R ${ACTORDB_USER}:${ACTORDB_GROUP} /var/log/actordb"
+
+#
+# Update node name.
+#
+if [ ! -f /etc/actordb/vm.args ]; then
+	log "err" "/etc/actordb/vm.args not found!!!"
+	exit 1
+fi
+
+if ! set | grep '^ACTORDB_NODE=' >/dev/null 2>&1; then
+	log "warn" "\$ACTORDB_NODE not set"
+	log "warn" "Using node name from /etc/actordb/vm.args"
+else
+	sed -i "s/^-name .*$/-name ${ACTORDB_NODE}/" /etc/actordb/vm.args
+	log "info" "Updated node name to ${ACTORDB_NODE} in /etc/actordb/vm.args"
+fi
 
 #
 # Start

--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -1,0 +1,131 @@
+#!/bin/sh -eu
+
+#
+# Variables
+#
+ACTORDB_USER=actordb
+ACTORDB_GROUP=actordb
+ACTORDB_UID=`id -u ${ACTORDB_USER}`
+ACTORDB_GID=`id -g ${ACTORDB_GROUP}`
+DEBUG_COMMANDS=0
+
+
+#
+# Functions
+#
+run() {
+	_cmd="${1}"
+	_debug="0"
+
+	_red="\033[0;31m"
+	_green="\033[0;32m"
+	_reset="\033[0m"
+	_user="$(whoami)"
+
+
+	# If 2nd argument is set and enabled, allow debug command
+	if [ "${#}" = "2" ]; then
+		if [ "${2}" = "1" ]; then
+			_debug="1"
+		fi
+	fi
+
+
+	if [ "${DEBUG_COMMANDS}" = "1" ] || [ "${_debug}" = "1" ]; then
+		printf "${_red}%s \$ ${_green}${_cmd}${_reset}\n" "${_user}"
+	fi
+	sh -c "LANG=C LC_ALL=C ${_cmd}"
+}
+
+log() {
+	_lvl="${1}"
+	_msg="${2}"
+
+	_clr_ok="\033[0;32m"
+	_clr_info="\033[0;34m"
+	_clr_warn="\033[0;33m"
+	_clr_err="\033[0;31m"
+	_clr_rst="\033[0m"
+
+	if [ "${_lvl}" = "ok" ]; then
+		printf "${_clr_ok}[OK]   %s${_clr_rst}\n" "${_msg}"
+	elif [ "${_lvl}" = "info" ]; then
+		printf "${_clr_info}[INFO] %s${_clr_rst}\n" "${_msg}"
+	elif [ "${_lvl}" = "warn" ]; then
+		printf "${_clr_warn}[WARN] %s${_clr_rst}\n" "${_msg}" 1>&2	# stdout -> stderr
+	elif [ "${_lvl}" = "err" ]; then
+		printf "${_clr_err}[ERR]  %s${_clr_rst}\n" "${_msg}" 1>&2	# stdout -> stderr
+	else
+		printf "${_clr_err}[???]  %s${_clr_rst}\n" "${_msg}" 1>&2	# stdout -> stderr
+	fi
+}
+
+# Test if argument is an integer.
+#
+# @param  mixed
+# @return integer	0: is int | 1: not an int
+isint() {
+	echo "${1}" | grep -Eq '^([0-9]|[1-9][0-9]*)$'
+}
+
+
+################################################################################
+# MAIN ENTRY POINT
+################################################################################
+
+#
+# Change UID
+#
+if ! set | grep '^NEW_UID=' >/dev/null 2>&1; then
+	log "warn" "\$NEW_UID not set"
+	log "warn" "Keeping user '${ACTORDB_USER}' with default uid: ${ACTORDB_UID}"
+else
+	if ! isint "${NEW_UID}"; then
+		log "err" "\$NEW_UID is not an integer: '${NEW_UID}'"
+		exit 1
+	else
+		log "info" "Changing user '${ACTORDB_USER}' uid to: ${NEW_UID}"
+		run "usermod -u ${NEW_UID} ${ACTORDB_USER}"
+	fi
+fi
+
+#
+# Change GID
+#
+if ! set | grep '^NEW_GID=' >/dev/null 2>&1; then
+	log "warn" "\$NEW_GID not set"
+	log "warn" "Keeping group '${ACTORDB_GROUP}' with default gid: ${ACTORDB_GID}"
+else
+	if ! isint "${NEW_GID}"; then
+		log "err" "\$NEW_GID is not an integer: '${NEW_GID}'"
+		exit 1
+	else
+		if _group_line="$( getent group "${NEW_GID}" )"; then
+			_group_name="$( echo "${_group_line}" | awk -F':' '{print $1}' )"
+			if [ "${_group_name}" != "${ACTORDB_GROUP}" ]; then
+				log "warn" "Group with ${NEW_GID} already exists: ${_group_name}"
+				log "info" "Changing GID of ${_group_name} to 9999"
+				run "groupmod -g 9999 ${_group_name}"
+			fi
+		fi
+
+		log "info" "Changing group '${ACTORDB_GROUP}' gid to: ${NEW_GID}"
+		run "groupmod -g ${NEW_GID} ${ACTORDB_GROUP}"
+	fi
+fi
+
+################################################################################
+# INSTALLATION
+################################################################################
+
+#
+# Fix ownership.
+#
+run "chown -R ${ACTORDB_USER}:${ACTORDB_GROUP} /var/lib/actordb"
+run "chown -R ${ACTORDB_USER}:${ACTORDB_GROUP} /etc/actordb"
+run "chown -R ${ACTORDB_USER}:${ACTORDB_GROUP} /var/log/actordb"
+
+#
+# Start
+#
+exec actordb foreground

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -2,6 +2,6 @@
 
 cd `dirname $0`
 
-rm node*/data/.erlang.cookie
-rm node*/data/lmdb*
-rm node*/logs/*.log*
+rm -f node*/data/.erlang.cookie
+rm -f node*/data/lmdb*
+rm -f node*/logs/*.log*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
-  actordb-server-1:
-    image: bytepixie/actordb
+  actordb1:
+    image: bytepixie/actordb:${ACTORDB_VERSION:-latest}
     environment:
       ##
       ## actordb user's UserID and GroupID
@@ -18,10 +18,10 @@ services:
     networks:
       default:
         aliases:
-          - actordb-server-1.local
+          - actordb1.local
 
-  actordb-server-2:
-    image: bytepixie/actordb
+  actordb2:
+    image: bytepixie/actordb:${ACTORDB_VERSION:-latest}
     environment:
       ##
       ## actordb user's UserID and GroupID
@@ -36,14 +36,14 @@ services:
       - "./node2/etc:/etc/actordb"
       - "./node2/logs:/var/log/actordb"
     links:
-      - actordb-server-1
+      - actordb1
     networks:
       default:
         aliases:
-          - actordb-server-2.local
+          - actordb2.local
 
-  actordb-server-3:
-    image: bytepixie/actordb
+  actordb3:
+    image: bytepixie/actordb:${ACTORDB_VERSION:-latest}
     environment:
       ##
       ## actordb user's UserID and GroupID
@@ -58,30 +58,31 @@ services:
       - "./node3/etc:/etc/actordb"
       - "./node3/logs:/var/log/actordb"
     links:
-      - actordb-server-1
+      - actordb1
     networks:
       default:
         aliases:
-          - actordb-server-3.local
+          - actordb3.local
 
   #
   # A single node per machine service, config in .env.
   #
-#  actordb-server:
-#    image: bytepixie/actordb
-#    environment:
-#      ##
-#      ## actordb user's UserID and GroupID
-#      ##
-#      - NEW_UID
-#      - NEW_GID
-#    ports:
-#      - "${ACTORDB_PORT_THRIFT-33306}:33306"
-#      - "${ACTORDB_PORT_MYSQL-33307}:33307"
-#    volumes:
-#      - "${ACTORDB_DATA-./data}:/var/lib/actordb"
-#      - "${ACTORDB_ETC-./etc}:/etc/actordb"
-#      - "${ACTORDB_LOGS-./logs}:/var/log/actordb"
+  actordb:
+    image: bytepixie/actordb:${ACTORDB_VERSION:-latest}
+    environment:
+      ##
+      ## actordb user's UserID and GroupID
+      ##
+      - NEW_UID
+      - NEW_GID
+      - ACTORDB_NODE=${ACTORDB_NODE:-actordb@actordb.local}
+    ports:
+      - "${ACTORDB_PORT_THRIFT:-33306}:33306"
+      - "${ACTORDB_PORT_MYSQL:-33307}:33307"
+    volumes:
+      - "${ACTORDB_DATA:-./actordb-data}:/var/lib/actordb"
+#      - "${ACTORDB_ETC:-./actordb-etc}:/etc/actordb"
+      - "${ACTORDB_LOGS:-./actordb-logs}:/var/log/actordb"
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2.1"
+version: "3"
 services:
   actordb-server-1:
     image: bytepixie/actordb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,13 @@
-version: "2"
+version: "2.1"
 services:
   actordb-server-1:
     image: bytepixie/actordb
+    environment:
+      ##
+      ## actordb user's UserID and GroupID
+      ##
+      - NEW_UID
+      - NEW_GID
     ports:
       - "33316:33306"
       - "33317:33307"
@@ -16,6 +22,12 @@ services:
 
   actordb-server-2:
     image: bytepixie/actordb
+    environment:
+      ##
+      ## actordb user's UserID and GroupID
+      ##
+      - NEW_UID
+      - NEW_GID
     ports:
       - "33326:33306"
       - "33327:33307"
@@ -32,6 +44,12 @@ services:
 
   actordb-server-3:
     image: bytepixie/actordb
+    environment:
+      ##
+      ## actordb user's UserID and GroupID
+      ##
+      - NEW_UID
+      - NEW_GID
     ports:
       - "33336:33306"
       - "33337:33307"
@@ -51,13 +69,19 @@ services:
   #
 #  actordb-server:
 #    image: bytepixie/actordb
+#    environment:
+#      ##
+#      ## actordb user's UserID and GroupID
+#      ##
+#      - NEW_UID
+#      - NEW_GID
 #    ports:
-#      - "${ACTORDB_PORT_THRIFT}:33306"
-#      - "${ACTORDB_PORT_MYSQL}:33307"
+#      - "${ACTORDB_PORT_THRIFT-33306}:33306"
+#      - "${ACTORDB_PORT_MYSQL-33307}:33307"
 #    volumes:
-#      - "${ACTORDB_DATA}:/var/lib/actordb"
-#      - "${ACTORDB_ETC}:/etc/actordb"
-#      - "${ACTORDB_LOGS}:/var/log/actordb"
+#      - "${ACTORDB_DATA-./data}:/var/lib/actordb"
+#      - "${ACTORDB_ETC-./etc}:/etc/actordb"
+#      - "${ACTORDB_LOGS-./logs}:/var/log/actordb"
 
 networks:
   default:

--- a/node1/etc/init.example.sql
+++ b/node1/etc/init.example.sql
@@ -8,8 +8,8 @@ use config
 insert into groups values ('grp1','cluster')
 -- localnode() is whatever is in vm.args (-name ....) for node we are connected to.
 insert into nodes values (localnode(),'grp1')
-insert into nodes values ('actordb@actordb2.local','grp1')
-insert into nodes values ('actordb@actordb3.local','grp1')
+insert into nodes values ('actordb2@actordb2.local','grp1')
+insert into nodes values ('actordb3@actordb3.local','grp1')
 CREATE USER 'root' IDENTIFIED BY 'rootpass'
 commit
 

--- a/node1/etc/init.example.sql
+++ b/node1/etc/init.example.sql
@@ -8,8 +8,8 @@ use config
 insert into groups values ('grp1','cluster')
 -- localnode() is whatever is in vm.args (-name ....) for node we are connected to.
 insert into nodes values (localnode(),'grp1')
-insert into nodes values ('node2@actordb-server-2.local','grp1')
-insert into nodes values ('node3@actordb-server-3.local','grp1')
+insert into nodes values ('actordb@actordb2.local','grp1')
+insert into nodes values ('actordb@actordb3.local','grp1')
 CREATE USER 'root' IDENTIFIED BY 'rootpass'
 commit
 

--- a/node1/etc/vm.args
+++ b/node1/etc/vm.args
@@ -1,5 +1,5 @@
 ## Name of the node
--name node1@actordb-server-1.local
+-name actordb@actordb1.local
 
 ## Cookie for distributed erlang
 -setcookie actordb

--- a/node1/etc/vm.args
+++ b/node1/etc/vm.args
@@ -1,5 +1,5 @@
 ## Name of the node
--name actordb@actordb1.local
+-name actordb1@actordb1.local
 
 ## Cookie for distributed erlang
 -setcookie actordb

--- a/node2/etc/vm.args
+++ b/node2/etc/vm.args
@@ -1,5 +1,5 @@
 ## Name of the node
--name actordb@actordb2.local
+-name actordb2@actordb2.local
 
 ## Cookie for distributed erlang
 -setcookie actordb

--- a/node2/etc/vm.args
+++ b/node2/etc/vm.args
@@ -1,5 +1,5 @@
 ## Name of the node
--name node2@actordb-server-2.local
+-name actordb@actordb2.local
 
 ## Cookie for distributed erlang
 -setcookie actordb

--- a/node3/etc/vm.args
+++ b/node3/etc/vm.args
@@ -1,5 +1,5 @@
 ## Name of the node
--name node3@actordb-server-3.local
+-name actordb@actordb3.local
 
 ## Cookie for distributed erlang
 -setcookie actordb

--- a/node3/etc/vm.args
+++ b/node3/etc/vm.args
@@ -1,5 +1,5 @@
 ## Name of the node
--name actordb@actordb3.local
+-name actordb3@actordb3.local
 
 ## Cookie for distributed erlang
 -setcookie actordb

--- a/sample.env
+++ b/sample.env
@@ -10,11 +10,13 @@ ACTORDB_PORT_MYSQL=33307
 # Following host directories can be specified as absolute or relative paths.
 # Relative paths should begin with "." or "..", and are relative to the docker-compose.yml file.
 #
-ACTORDB_DATA=./data
-ACTORDB_ETC=./etc
-ACTORDB_LOGS=./logs
+ACTORDB_DATA=./actordb-data
+ACTORDB_ETC=./actordb-etc
+ACTORDB_LOGS=./actordb-logs
 #
 # Set actordb user's UID and GID to match host's user (important for Linux).
 #
 NEW_UID=1000
 NEW_GID=1000
+
+ACTORDB_NODE=actordb@actordb.local

--- a/sample.env
+++ b/sample.env
@@ -1,4 +1,7 @@
 #
+# Sample .env
+#
+#
 # Docker Compose file needs following env vars set.
 #
 ACTORDB_PORT_THRIFT=33306
@@ -10,3 +13,8 @@ ACTORDB_PORT_MYSQL=33307
 ACTORDB_DATA=./data
 ACTORDB_ETC=./etc
 ACTORDB_LOGS=./logs
+#
+# Set actordb user's UID and GID to match host's user (important for Linux).
+#
+NEW_UID=1000
+NEW_GID=1000


### PR DESCRIPTION
Added ability to set the UID and GID for the actordb user that runs the actordb process so that they can be matched with the user running the container. This allows for easier management of the data and log files on the host, especially when using Linux (which doesn't have the same hacks in place that Docker for macOS and Windows do for writing everything to the host with matched IDs).